### PR TITLE
Escape image source in RegExp test, quote image source in applied background style attribute

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "picturefill-background",
-    "version": "1.0.0",
+    "version": "1.0.2",
     "license": "MIT",
     "keywords": [
         "picture",

--- a/picturefill-background.js
+++ b/picturefill-background.js
@@ -2,6 +2,13 @@
     "use strict";
 
     /**
+     * Utilities
+     */
+    var escapeRegExp = function( string ) {
+        return string.replace( /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&' );
+    };
+
+    /**
      * Default options
      * Redefine this value to replace some of the options
      * (ex: w.picturefillBackgroundOptions.selector = "custom";)
@@ -34,11 +41,11 @@
 
             if ( matches.length ) {
                 src = matches.pop();
-                var exp = new RegExp( src );
+                var exp = new RegExp( escapeRegExp( src ) );
 
                 // Update target element's background image, if necessary
                 if ( !exp.test( picturefills[ i ].style.backgroundImage ) ) {
-                    picturefills[i].style.backgroundImage = "url(" + src + ")";
+                    picturefills[i].style.backgroundImage = "url('" + src + "')";
                     picturefills[i].style.backgroundSize = w.picturefillBackgroundOptions.backgroundSize;
                     picturefills[i].style.backgroundRepeat = w.picturefillBackgroundOptions.backgroundRepeat;
                     picturefills[i].style.backgroundPosition = w.picturefillBackgroundOptions.backgroundPosition;

--- a/picturefill-background.js
+++ b/picturefill-background.js
@@ -5,7 +5,7 @@
      * Utilities
      */
     var escapeRegExp = function( string ) {
-        return string.replace( /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&' );
+        return string.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
     };
 
     /**


### PR DESCRIPTION
This PR allows the use of image URLs containing special characters that would previously cause either the RexExp test to fail or result in an invalid background style attribute being applied, which would then be ignored by the browser.