### PR TITLE
Changing this to window to fix scope for module loaders

### DIFF
--- a/picturefill-background.js
+++ b/picturefill-background.js
@@ -69,4 +69,4 @@
         w.attachEvent( "onload", w.picturefillBackground );
     }
 
-}( this ));
+}( window ));


### PR DESCRIPTION
An issue was opened here: https://github.com/M6Web/picturefill-background/issues/8

In order to have this javascript work with imports I had to change this to window to fix the scope.